### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/denwakeup/mcp-simple-gateway/security/code-scanning/1](https://github.com/denwakeup/mcp-simple-gateway/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify `contents: read`, which is sufficient for the current workflow since it only needs to read the repository contents to install dependencies and run tests. This change ensures that the workflow adheres to the principle of least privilege and avoids granting unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
