### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,8 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Potential fix for [https://github.com/denwakeup/mcp-simple-gateway/security/code-scanning/2](https://github.com/denwakeup/mcp-simple-gateway/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the `validate` job, explicitly setting the permissions to `contents: read`. This ensures that the job has only the minimal permissions required to perform its tasks, such as reading repository contents. The `release` job already has an explicit `permissions` block, so no changes are needed there.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
